### PR TITLE
Read imagesize from $imgData

### DIFF
--- a/src/getID3/getid3_lib.php
+++ b/src/getID3/getid3_lib.php
@@ -997,16 +997,7 @@ class getid3_lib
 
 
 	public static function GetDataImageSize($imgData, &$imageinfo=array()) {
-		$GetDataImageSize = false;
-		if ($tempfilename = tempnam(sys_get_temp_dir(), 'gI3')) {
-			if (is_writable($tempfilename) && is_file($tempfilename) && ($tmp = fopen($tempfilename, 'wb'))) {
-				fwrite($tmp, $imgData);
-				fclose($tmp);
-				$GetDataImageSize = @getimagesize($tempfilename, $imageinfo);
-			}
-			unlink($tempfilename);
-		}
-		return $GetDataImageSize;
+		return @getimagesizefromstring($imgData, $imageinfo);
 	}
 
 	public static function ImageExtFromMime($mime_type) {


### PR DESCRIPTION
Alter GetDataImageSize to read the imagesize from image data instead of writing it to disk first.

Have not tested the pr extensively :see_no_evil: Required for https://github.com/nextcloud/server/issues/17291