### PR TITLE
Fix deprecation warning with PHP 8.1

### DIFF
--- a/src/getID3/getid3_lib.php
+++ b/src/getID3/getid3_lib.php
@@ -1147,7 +1147,7 @@ class getid3_lib
 	* @param string $suffix If the name component ends in suffix this will also be cut off.
 	* @return string
 	*/
-	public static function mb_basename($path, $suffix = null) {
+	public static function mb_basename($path, $suffix = '') {
 		$splited = preg_split('#/#', rtrim($path, '/ '));
 		return substr(basename('X'.$splited[count($splited) - 1], $suffix), 1);
 	}


### PR DESCRIPTION
Fix deprecation warning with PHP 8.1: 
PHP Deprecated:  basename(): Passing null to parameter #2 ($suffix) of type string is deprecated in […]/christophwurst/id3parser/src/getID3/getid3_lib.php on line 1152